### PR TITLE
Update reactComponentES6.js

### DIFF
--- a/templates/reactComponentES6.js
+++ b/templates/reactComponentES6.js
@@ -1,7 +1,8 @@
 /* ES6 Syntax */
 
 var ES6 = 
-`import React, { Component, PropTypes } from 'react'
+`//import React, { Component } from 'react';
+import PropTypes from 'prop-types'; // ES6
 [import-css-file]
 
 class [comp] extends Component {

--- a/templates/reactComponentES6.js
+++ b/templates/reactComponentES6.js
@@ -1,7 +1,7 @@
 /* ES6 Syntax */
 
 var ES6 = 
-`//import React, { Component } from 'react';
+`import React, { Component } from 'react';
 import PropTypes from 'prop-types'; // ES6
 [import-css-file]
 


### PR DESCRIPTION
adds the ES6 version of how to import PropTypes since PropTypes have been depricated.